### PR TITLE
use spring support for jersey hyper schema generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .classpath
 target
 
+.idea
+*.iml
+

--- a/factcast-server-rest/pom.xml
+++ b/factcast-server-rest/pom.xml
@@ -30,9 +30,9 @@
 			<artifactId>spring-boot-starter-jetty</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.mercateo</groupId>
-			<artifactId>common.rest.schemagen</artifactId>
-			<version>0.18.5</version>
+			<groupId>com.mercateo.rest</groupId>
+			<artifactId>rest-schemagen-spring</artifactId>
+			<version>0.1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/FactCastRestApplication.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/FactCastRestApplication.java
@@ -17,7 +17,6 @@ public class FactCastRestApplication extends ResourceConfig {
 		// Register resources and providers using package-scanning.
 		final String resourceBasePackage = "org.factcast.server.rest.resources";
 		packages(resourceBasePackage);
-		LinkFactoryResourceConfig.configure(this);
 		register(NoCacheFilter.class);
 		register(CachableFilter.class);
 	}

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/FactCastServerConfiguration.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/FactCastServerConfiguration.java
@@ -1,39 +1,42 @@
 package org.factcast.server.rest;
 
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.link.LinkMetaFactory;
+import com.mercateo.common.rest.schemagen.plugin.FieldCheckerForSchema;
+import com.mercateo.common.rest.schemagen.plugin.MethodCheckerForLink;
+import com.mercateo.rest.schemagen.spring.JerseyHateoasConfiguration;
 import org.factcast.core.store.FactStore;
+import org.factcast.server.rest.resources.EventsResource;
+import org.factcast.server.rest.resources.RootResource;
 import org.factcast.store.inmem.InMemFactStore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.mercateo.common.rest.schemagen.JsonHyperSchemaCreator;
-import com.mercateo.common.rest.schemagen.JsonSchemaGenerator;
-import com.mercateo.common.rest.schemagen.RestJsonSchemaGenerator;
-import com.mercateo.common.rest.schemagen.types.ObjectWithSchemaCreator;
-import com.mercateo.common.rest.schemagen.types.PaginatedResponseBuilderCreator;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import(JerseyHateoasConfiguration.class)
 public class FactCastServerConfiguration {
 
 	private InMemFactStore inMemFactStore = new InMemFactStore();
 
 	@Bean
-	public JsonSchemaGenerator jsonSchemaGenerator() {
-		return new RestJsonSchemaGenerator();
+	FieldCheckerForSchema fieldCheckerForSchema() {
+		return (field, callContext) -> true;
 	}
 
 	@Bean
-	JsonHyperSchemaCreator jsonHyperSchemaCreator() {
-		return new JsonHyperSchemaCreator();
+	MethodCheckerForLink methodCheckerForLink() {
+		return (scope) -> true;
 	}
 
 	@Bean
-	ObjectWithSchemaCreator objectWithSchemaCreator() {
-		return new ObjectWithSchemaCreator();
+	LinkFactory<RootResource> rootResourceLinkFactory(LinkMetaFactory linkMetaFactory) {
+		return linkMetaFactory.createFactoryFor(RootResource.class);
 	}
 
 	@Bean
-	PaginatedResponseBuilderCreator paginatedResponseBuilderCreator() {
-		return new PaginatedResponseBuilderCreator();
+	LinkFactory<EventsResource> eventsResourceLinkFactory(LinkMetaFactory linkMetaFactory) {
+		return linkMetaFactory.createFactoryFor(EventsResource.class);
 	}
 
 	@Bean

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventObserver.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventObserver.java
@@ -1,32 +1,24 @@
 package org.factcast.server.rest.resources;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.UUID;
-
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.MediaType;
-
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.link.relation.Rel;
+import com.mercateo.common.rest.schemagen.types.HyperSchemaCreator;
+import lombok.AllArgsConstructor;
+import lombok.val;
 import org.factcast.core.Fact;
 import org.factcast.core.subscription.FactStoreObserver;
 import org.glassfish.jersey.media.sse.EventOutput;
 import org.glassfish.jersey.media.sse.OutboundEvent;
 
-import com.mercateo.common.rest.schemagen.JsonHyperSchema;
-import com.mercateo.common.rest.schemagen.link.LinkFactory;
-import com.mercateo.common.rest.schemagen.link.relation.Rel;
-import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.UUID;
 
-import lombok.NonNull;
-
+@AllArgsConstructor
 public class EventObserver implements FactStoreObserver {
 	private final EventOutput eventOutput;
-	private LinkFactory<EventsResource> linkFatory;
-
-	public EventObserver(@NonNull EventOutput eventOutput, @NonNull LinkFactory<EventsResource> linkFatory) {
-		this.eventOutput = eventOutput;
-		this.linkFatory = linkFatory;
-	}
+	private final LinkFactory<EventsResource> linkFatory;
+	private final HyperSchemaCreator hyperSchemaCreator;
 
 	@Override
 	public void onNext(Fact f) {
@@ -35,9 +27,8 @@ public class EventObserver implements FactStoreObserver {
 		final OutboundEvent.Builder eventBuilder = new OutboundEvent.Builder();
 		eventBuilder.name("new-event");
 		String toReturn = t.toString();
-		Optional<Link> linkToEvent = linkFatory.forCall(Rel.CANONICAL, r -> r.getForId(toReturn));
-		ObjectWithSchema<EventIdJson> withSchema = ObjectWithSchema.create(new EventIdJson(toReturn),
-				JsonHyperSchema.from(linkToEvent));
+		val linkToEvent = linkFatory.forCall(Rel.CANONICAL, r -> r.getForId(toReturn));
+		val withSchema = hyperSchemaCreator.create(new EventIdJson(toReturn), linkToEvent);
 		eventBuilder.data(withSchema);
 		eventBuilder.mediaType(MediaType.APPLICATION_JSON_TYPE);
 		final OutboundEvent event = eventBuilder.build();

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventObserverFactory.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventObserverFactory.java
@@ -1,0 +1,20 @@
+package org.factcast.server.rest.resources;
+
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.types.HyperSchemaCreator;
+import lombok.AllArgsConstructor;
+import org.glassfish.jersey.media.sse.EventOutput;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+class EventObserverFactory {
+
+	private final LinkFactory<EventsResource> eventsResourceLinkFactory;
+
+	private final HyperSchemaCreator hyperSchemaCreator;
+
+	EventObserver createFor(EventOutput eventOutput) {
+		return new EventObserver(eventOutput, eventsResourceLinkFactory, hyperSchemaCreator);
+	}
+}

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventsSchemaCreator.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/EventsSchemaCreator.java
@@ -1,0 +1,31 @@
+package org.factcast.server.rest.resources;
+
+import static com.mercateo.common.rest.schemagen.util.OptionalUtil.collect;
+
+import java.util.Optional;
+
+import javax.ws.rs.core.Link;
+
+import org.springframework.stereotype.Component;
+
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.link.relation.Rel;
+import com.mercateo.common.rest.schemagen.types.HyperSchemaCreator;
+import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
+
+import lombok.AllArgsConstructor;
+
+@Component
+@AllArgsConstructor
+class EventsSchemaCreator {
+
+    private final LinkFactory<EventsResource> eventsResourceLinkFactory;
+
+    private final HyperSchemaCreator hyperSchemaCreator;
+
+    ObjectWithSchema<FactJson> forFactWithId(FactJson returnValue, String id) {
+        Optional<Link> selfLink = eventsResourceLinkFactory.forCall(Rel.SELF, r -> r.getForId(id));
+
+        return hyperSchemaCreator.create(returnValue, collect(selfLink));
+    }
+}

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/RootResource.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/RootResource.java
@@ -13,21 +13,19 @@ import com.mercateo.common.rest.schemagen.JerseyResource;
 import com.mercateo.common.rest.schemagen.JsonHyperSchema;
 import com.mercateo.common.rest.schemagen.link.LinkMetaFactory;
 import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Path("/")
-
+@Component
+@AllArgsConstructor
 public class RootResource implements JerseyResource {
 
-	@Inject
-	private LinkMetaFactory linkMetaFactory;
+	private final RootSchemaCreator schemaCreator;
 
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public ObjectWithSchema<Void> getRoot() {
-		Optional<Link> eventsLink = linkMetaFactory.createFactoryFor(EventsResource.class).forCall(EventsRel.EVENTS,
-				r -> r.getServerSentEvents(null));
-
-		return ObjectWithSchema.create(null, JsonHyperSchema.from(eventsLink));
-
+		return schemaCreator.forRoot();
 	}
 }

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/RootSchemaCreator.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/RootSchemaCreator.java
@@ -1,0 +1,25 @@
+package org.factcast.server.rest.resources;
+
+import com.mercateo.common.rest.schemagen.link.LinkFactory;
+import com.mercateo.common.rest.schemagen.types.HyperSchemaCreator;
+import com.mercateo.common.rest.schemagen.types.ObjectWithSchema;
+import lombok.AllArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Component;
+
+import static com.mercateo.common.rest.schemagen.util.OptionalUtil.collect;
+
+@Component
+@AllArgsConstructor
+class RootSchemaCreator {
+	private final HyperSchemaCreator hyperSchemaCreator;
+
+	private final LinkFactory<EventsResource> eventsResourceLinkFactory;
+
+	ObjectWithSchema<Void> forRoot() {
+		val getEventsLink = eventsResourceLinkFactory.forCall(EventsRel.EVENTS, r -> r
+				.getServerSentEvents(null));
+
+		return hyperSchemaCreator.create(null, collect(getEventsLink));
+	}
+}


### PR DESCRIPTION
Use direct spring support for rest-schemagen. No more HK2 as Spring is used to create the Resource instances as well. 

Security is not yet ready there, but I'm happy to add it when required.