### PR TITLE
Array of ids in meta data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 
 **/bin/*
 *.versionsBackup*
+.factorypath
+

--- a/factcast-core/src/main/java/org/factcast/core/DefaultFact.java
+++ b/factcast-core/src/main/java/org/factcast/core/DefaultFact.java
@@ -23,9 +23,9 @@ import lombok.SneakyThrows;
  * Note: creating an instance involves deserializing the header from JS. This is
  * probably not optimal considering performance. If you extend FactCast,
  * consider creating a dedicated Fact Impl.
- * 
+ *
  * For caching purposes, this thing should be Externalizable.
- * 
+ *
  * @see PGFact
  * @author uwe.schaefer@mercateo.com
  *
@@ -86,11 +86,11 @@ public class DefaultFact implements Fact, Externalizable {
         Set<UUID> aggIds;
 
         @JsonProperty
-        final Map<String, String> meta = new HashMap<>();
+        final Map<String, Object> meta = new HashMap<>();
     }
 
     @Override
-    public String meta(String key) {
+    public Object meta(String key) {
         return deserializedHeader.meta.get(key);
     }
 

--- a/factcast-core/src/main/java/org/factcast/core/Fact.java
+++ b/factcast-core/src/main/java/org/factcast/core/Fact.java
@@ -34,12 +34,12 @@ public interface Fact {
     @NonNull
     String jsonPayload();
 
-    String meta(String key);
+    Object meta(String key);
 
     default long serial() {
-        String s = meta("_ser");
+        Object s = meta("_ser");
         if (s != null) {
-            return Long.valueOf(s).longValue();
+            return Long.valueOf(String.valueOf(s)).longValue();
         } else {
             throw new IllegalStateException("'_ser' Meta attribute not found");
         }

--- a/factcast-core/src/main/java/org/factcast/core/spec/FactSpec.java
+++ b/factcast-core/src/main/java/org/factcast/core/spec/FactSpec.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 
 /**
  * Defines a Specification of facts to match for a subscription.
- * 
+ *
  * @author uwe.schaefer@mercateo.com
  *
  */
@@ -37,7 +37,7 @@ public class FactSpec {
 
     @NonNull
     @JsonProperty
-    final Map<String, String> meta = new HashMap<>();
+    final Map<String, Object> meta = new HashMap<>();
 
     public FactSpec meta(@NonNull String k, @NonNull String v) {
         meta.put(k, v);

--- a/factcast-core/src/main/java/org/factcast/core/spec/FactSpecMatcher.java
+++ b/factcast-core/src/main/java/org/factcast/core/spec/FactSpecMatcher.java
@@ -36,7 +36,7 @@ public final class FactSpecMatcher implements Predicate<Fact> {
 
     final UUID aggId;
 
-    final Map<String, String> meta;
+    final Map<String, Object> meta;
 
     final String script;
 

--- a/factcast-core/src/test/java/org/factcast/core/DefaultFact0Test.java
+++ b/factcast-core/src/test/java/org/factcast/core/DefaultFact0Test.java
@@ -1,5 +1,6 @@
 package org.factcast.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
@@ -54,7 +55,7 @@ public class DefaultFact0Test {
     public void testMetaDeser() throws Exception {
         Fact f = DefaultFact.of("{\"id\":\"" + UUID.randomUUID()
                 + "\",\"ns\":\"default\",\"meta\":{\"foo\":7}}", "{}");
-        assertEquals("7", f.meta("foo"));
+        assertEquals(Integer.valueOf(7), f.meta("foo"));
     }
 
     @Test
@@ -115,7 +116,7 @@ public class DefaultFact0Test {
         final UUID aid = UUID.randomUUID();
         Fact f = DefaultFact.of("{\"id\":\"" + id
                 + "\",\"ns\":\"narf\",\"type\":\"foo\",\"aggIds\":[\"" + aid
-                + "\"],\"meta\":{\"foo\":7}}", "{}");
+                + "\"],\"meta\":{\"foo\":128}}", "{}");
 
         Fact copy = copyBySerialization(f);
 
@@ -150,4 +151,35 @@ public class DefaultFact0Test {
         assertEquals(f1, f2);
 
     }
+
+    @Test
+    public void testArrayOfIdsInMeta() throws Exception {
+
+        // given
+        UUID id = UUID.randomUUID();
+        UUID metaId1 = UUID.randomUUID();
+        UUID metaId2 = UUID.randomUUID();
+        UUID metaId3 = UUID.randomUUID();
+        // @formatter:off
+        String header = "{\"id\":\""+id+ "\",\"ns\":\"narf\",\"type\":\"foo\",\"aggIds\":[\""+id+"\"]," 
+                + "\"meta\":{" 
+                    + "\"ids\":[\"" 
+                        + metaId1 + "\",\"" 
+                        + metaId2 + "\",\"" 
+                        + metaId3 + "\"" 
+                    + "]"
+                + "}}";
+        // @formatter:on
+
+        // when
+        Fact f = DefaultFact.of(header, "{}");
+
+        // then
+        assertThat(f.meta("ids")).asList().containsExactlyInAnyOrder( //
+                metaId1.toString(), //
+                metaId2.toString(), //
+                metaId3.toString());
+
+    }
+
 }

--- a/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/FactJson.java
+++ b/factcast-server-rest/src/main/java/org/factcast/server/rest/resources/FactJson.java
@@ -25,7 +25,7 @@ import lombok.Value;
 /**
  * return object for the resources returning facts to the client. Also used in
  * the new transactions in the payload
- * 
+ *
  * @author joerg_adler
  *
  */
@@ -66,7 +66,7 @@ public class FactJson {
         final Set<UUID> aggIds;
 
         @JsonProperty
-        final Map<String, String> meta = new HashMap<>();
+        final Map<String, Object> meta = new HashMap<>();
 
         @JsonAnySetter
         @IgnoreInRestSchema

--- a/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/query/PGQueryBuilder0Test.java
+++ b/factcast-store-pgsql/src/test/java/org/factcast/store/pgsql/internal/query/PGQueryBuilder0Test.java
@@ -1,0 +1,56 @@
+package org.factcast.store.pgsql.internal.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Arrays;
+
+import org.factcast.core.subscription.SubscriptionRequestTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class PGQueryBuilder0Test {
+
+    private PGQueryBuilder uut;
+
+    @Mock
+    private SubscriptionRequestTO request;
+
+    @Before
+    public void init() {
+        initMocks(this);
+        uut = new PGQueryBuilder(request);
+    }
+
+    @Test
+    public void testExtractMetaJson() throws Exception {
+
+        // given
+        String key = "k";
+        Object value = "v";
+
+        // when
+        String json = uut.extractMetaJson(key, value);
+
+        // then
+        assertThat(json).isEqualTo("{\"meta\":{\"k\":\"v\" }}");
+
+    }
+
+    @Test
+    public void testExtractMetaJson_with_multi_ids() throws Exception {
+
+        // given
+        String key = "k";
+        Object value = Arrays.asList("v1", "v2", "v3");
+
+        // when
+        String json = uut.extractMetaJson(key, value);
+
+        // then
+        assertThat(json).isEqualTo("{\"meta\":{\"k\":[\"v1\",\"v2\",\"v3\"] }}");
+
+    }
+
+}


### PR DESCRIPTION
as we'd like to publich events with metadata that contains multiple ids for the same key (e.g. "ids":["id1","id2",...]) I changed the map for meta from string,string to string,object.

remark:
FactSpecMatcher0Test wasnt adjusted because org.factcast.core.spec.FactSpecMatcher.metaMatch(Fact) does not fullfil the requirements to have metadata as object. and this metaMatch is only used in test. hence either I write code for a test just to test this code or I don't write anything there. 